### PR TITLE
Fix indexing in mapWithIndexArray and traverseArrayImpl

### DIFF
--- a/src/Data/FunctorWithIndex.lua
+++ b/src/Data/FunctorWithIndex.lua
@@ -3,7 +3,7 @@ return {
     return function(xs)
       local l = #xs
       local result = {}
-      for i = 1, l do result[i] = f(i)(xs[i]) end
+      for i = 1, l do result[i] = f(i - 1)(xs[i]) end
       return result
     end
   end)

--- a/src/Data/Traversable.lua
+++ b/src/Data/Traversable.lua
@@ -25,7 +25,7 @@ return {
               end
             end
 
-            return go(0, #array)
+            return go(1, #array + 1)
           end
         end
       end


### PR DESCRIPTION
**Description of the change**

Changes are made such that lua arrays use the lua convention of 1 based indexing while purescript arrays use 0 based indexing.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
