### PR TITLE
Fix `traverse` failing at runtime

### DIFF
--- a/src/Data/Traversable.lua
+++ b/src/Data/Traversable.lua
@@ -1,31 +1,32 @@
 local array1 = function(a) return {a} end
 local array2 = function(a) return function(b) return {a, b} end end
 local array3 = function(a) return function(b) return function(c) return {a, b, c} end end end
-local concat2 = function(xs) return function(ys) return table.concat(xs, ys) end end
 return {
   traverseArrayImpl = (function(apply)
     return function(map)
       return function(pure)
-        return function(f)
-          return function(array)
-            local function go(bot, top)
-              if top - bot == 0 then
-                return pure({})
-              elseif top - bot == 1 then
-                return map(array1)(f(array[bot]))
-              elseif top - bot == 2 then
-                return apply(map(array2)(f(array[bot])))(f(array[bot + 1]))
-              elseif top - bot == 3 then
-                return apply(apply(map(array3)(f(array[bot])))(f(array[bot + 1])))(f(array[bot + 2]))
-              else
-                -- This slightly tricky pivot selection aims to produce two
-                -- even-length partitions where possible.
-                local pivot = bot + math.floor((top - bot) / 4) * 2
-                return apply(map(concat2)(go(bot, pivot)))(go(pivot, top))
+        return function (appendArrays)
+          return function(f)
+            return function(array)
+              local function go(bot, top)
+                if top - bot == 0 then
+                  return pure({})
+                elseif top - bot == 1 then
+                  return map(array1)(f(array[bot]))
+                elseif top - bot == 2 then
+                  return apply(map(array2)(f(array[bot])))(f(array[bot + 1]))
+                elseif top - bot == 3 then
+                  return apply(apply(map(array3)(f(array[bot])))(f(array[bot + 1])))(f(array[bot + 2]))
+                else
+                  -- This slightly tricky pivot selection aims to produce two
+                  -- even-length partitions where possible.
+                  local pivot = bot + math.floor((top - bot) / 4) * 2
+                  return apply(map(appendArrays)(go(bot, pivot)))(go(pivot, top))
+                end
               end
-            end
 
-            return go(0, #array)
+              return go(0, #array)
+            end
           end
         end
       end

--- a/src/Data/Traversable.lua
+++ b/src/Data/Traversable.lua
@@ -12,11 +12,11 @@ return {
                 if top - bot == 0 then
                   return pure({})
                 elseif top - bot == 1 then
-                  return map(array1)(f(array[bot]))
+                  return map(array1)(f(array[bot + 1]))
                 elseif top - bot == 2 then
-                  return apply(map(array2)(f(array[bot])))(f(array[bot + 1]))
+                  return apply(map(array2)(f(array[bot + 1])))(f(array[bot + 2]))
                 elseif top - bot == 3 then
-                  return apply(apply(map(array3)(f(array[bot])))(f(array[bot + 1])))(f(array[bot + 2]))
+                  return apply(apply(map(array3)(f(array[bot + 1])))(f(array[bot + 2])))(f(array[bot + 3]))
                 else
                   -- This slightly tricky pivot selection aims to produce two
                   -- even-length partitions where possible.

--- a/src/Data/Traversable.purs
+++ b/src/Data/Traversable.purs
@@ -100,7 +100,7 @@ sequenceDefault
 sequenceDefault = traverse identity
 
 instance traversableArray :: Traversable Array where
-  traverse = traverseArrayImpl apply map pure
+  traverse = traverseArrayImpl apply map pure (<>)
   sequence = sequenceDefault
 
 foreign import traverseArrayImpl
@@ -108,6 +108,7 @@ foreign import traverseArrayImpl
    . (forall x y. m (x -> y) -> m x -> m y)
   -> (forall x y. (x -> y) -> m x -> m y)
   -> (forall x. x -> m x)
+  -> (forall x. Array x -> Array x -> Array x)
   -> (a -> m b)
   -> Array a
   -> m (Array b)


### PR DESCRIPTION
**Description of the change**

`traverse` is failing at runtime due to 2 reasons:
- It is using `table.concat` for array concatenation, which does not do that.
- It's Lua implementation is equivalent to its JS implementation, not considering Lua array indicies start from 1, not 0 as in JS.

This PR fixes both.

---

**Checklist:**

- [ ] ~~Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")~~
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
